### PR TITLE
ターゲットフレームワークを .NET 8.0 に更新

### DIFF
--- a/AupInfo.Core/AupInfo.Core.csproj
+++ b/AupInfo.Core/AupInfo.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Version>0.1.1</Version>

--- a/AupInfo.Core/AupInfo.Core.csproj
+++ b/AupInfo.Core/AupInfo.Core.csproj
@@ -12,10 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Karoterra.AupDotNet" Version="0.1.1" />
+    <PackageReference Include="Karoterra.AupDotNet" Version="0.2.0" />
     <PackageReference Include="Prism.Core" Version="8.1.97" />
-    <PackageReference Include="ReactiveProperty" Version="8.1.2" />
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+    <PackageReference Include="ReactiveProperty" Version="9.7.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.13" />
   </ItemGroup>
 
 </Project>

--- a/AupInfo.Wpf/App.xaml
+++ b/AupInfo.Wpf/App.xaml
@@ -2,42 +2,23 @@
                         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                         xmlns:prism="http://prismlibrary.com/"
+                        xmlns:md="http://materialdesigninxaml.net/winfx/xaml/themes"
                         xmlns:converter="clr-namespace:AupInfo.Wpf.Converters">
   <Application.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
+        <md:MahAppsBundledTheme BaseTheme="Inherit" PrimaryColor="DeepPurple" SecondaryColor="Purple" />
+
+        <!-- MahApps -->
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Themes/Light.Violet.xaml" />
 
-        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Dark.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
+        <!-- Material Design -->
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign2.Defaults.xaml" />
 
-        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Fonts.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Flyout.xaml" />
+        <!-- Material Design: MahApps Compatibility -->
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Defaults.xaml" />
       </ResourceDictionary.MergedDictionaries>
-
-      <SolidColorBrush x:Key="HighlightBrush" Color="{DynamicResource Primary700}"/>
-      <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{DynamicResource Primary600}" />
-      <SolidColorBrush x:Key="AccentColorBrush" Color="{DynamicResource Primary500}"/>
-      <SolidColorBrush x:Key="AccentColorBrush2" Color="{DynamicResource Primary400}"/>
-      <SolidColorBrush x:Key="AccentColorBrush3" Color="{DynamicResource Primary300}"/>
-      <SolidColorBrush x:Key="AccentColorBrush4" Color="{DynamicResource Primary200}"/>
-      <SolidColorBrush x:Key="WindowTitleColorBrush" Color="{DynamicResource Primary700}"/>
-      <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{DynamicResource Primary500Foreground}"/>
-      <LinearGradientBrush x:Key="ProgressBrush" EndPoint="0.001,0.5" StartPoint="1.002,0.5">
-        <GradientStop Color="{DynamicResource Primary700}" Offset="0"/>
-        <GradientStop Color="{DynamicResource Primary300}" Offset="1"/>
-      </LinearGradientBrush>
-      <SolidColorBrush x:Key="CheckmarkFill" Color="{DynamicResource Primary500}"/>
-      <SolidColorBrush x:Key="RightArrowFill" Color="{DynamicResource Primary500}"/>
-      <SolidColorBrush x:Key="IdealForegroundColorBrush" Color="{DynamicResource Primary500Foreground}"/>
-      <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{DynamicResource Primary500}" Opacity="0.4"/>
-      <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{DynamicResource Primary500}" />
-      <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{DynamicResource Primary400}" />
-      <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{DynamicResource Primary500Foreground}" />
 
       <converter:NullableToVisibilityConverter x:Key="NullableToVisibility"/>
       <converter:ToReadableSizeConverter x:Key="ToReadableSize"/>

--- a/AupInfo.Wpf/AupInfo.Wpf.csproj
+++ b/AupInfo.Wpf/AupInfo.Wpf.csproj
@@ -15,11 +15,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MahApps.Metro" Version="2.4.9" />
-    <PackageReference Include="MaterialDesignThemes.MahApps" Version="0.2.5" />
-    <PackageReference Include="Octokit" Version="4.0.1" />
+    <PackageReference Include="MahApps.Metro" Version="2.4.10" />
+    <PackageReference Include="MaterialDesignThemes.MahApps" Version="5.2.1" />
+    <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="Prism.DryIoc" Version="8.1.97" />
-    <PackageReference Include="ReactiveProperty.WPF" Version="8.1.2" />
+    <PackageReference Include="ReactiveProperty.WPF" Version="9.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AupInfo.Wpf/AupInfo.Wpf.csproj
+++ b/AupInfo.Wpf/AupInfo.Wpf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>

--- a/AupInfo.Wpf/Views/MainWindow.xaml
+++ b/AupInfo.Wpf/Views/MainWindow.xaml
@@ -116,7 +116,7 @@
       <DockPanel>
         <md:ColorZone Padding="16"
                       DockPanel.Dock="Top"
-                      md:ShadowAssist.ShadowDepth="Depth2"
+                      md:ElevationAssist.Elevation="Dp4"
                       Mode="PrimaryLight">
           <DockPanel>
             <StackPanel Orientation="Horizontal">


### PR DESCRIPTION
.NET 6.0 のサポート期間が終了したため、ターゲットフレームワークを .NET 8.0 に更新した。
AupDotNetをはじめ依存パッケージを更新した。